### PR TITLE
Add the option to skip into the raw data and only read a set number of time steps

### DIFF
--- a/cdmt.cu
+++ b/cdmt.cu
@@ -118,6 +118,7 @@ int main(int argc,char *argv[])
       }
     }
   } else {
+    printf("Unknown option '%c'\n", arg);
     usage();
     return 0;
   }

--- a/cdmt.cu
+++ b/cdmt.cu
@@ -152,40 +152,40 @@ int main(int argc,char *argv[])
   checkCudaErrors(cudaSetDevice(device));
 
   // Allocate memory for complex timeseries
-  checkCudaErrors(cudaMalloc((void **) &cp1,sizeof(cufftComplex)*nbin*nfft*nsub));
-  checkCudaErrors(cudaMalloc((void **) &cp2,sizeof(cufftComplex)*nbin*nfft*nsub));
-  checkCudaErrors(cudaMalloc((void **) &cp1p,sizeof(cufftComplex)*nbin*nfft*nsub));
-  checkCudaErrors(cudaMalloc((void **) &cp2p,sizeof(cufftComplex)*nbin*nfft*nsub));
+  checkCudaErrors(cudaMalloc((void **) &cp1, (size_t) sizeof(cufftComplex)*nbin*nfft*nsub));
+  checkCudaErrors(cudaMalloc((void **) &cp2, (size_t) sizeof(cufftComplex)*nbin*nfft*nsub));
+  checkCudaErrors(cudaMalloc((void **) &cp1p,(size_t) sizeof(cufftComplex)*nbin*nfft*nsub));
+  checkCudaErrors(cudaMalloc((void **) &cp2p,(size_t) sizeof(cufftComplex)*nbin*nfft*nsub));
 
   // Allocate device memory for chirp
-  checkCudaErrors(cudaMalloc((void **) &dc,sizeof(cufftComplex)*nbin*nsub*ndm));
+  checkCudaErrors(cudaMalloc((void **) &dc, (size_t) sizeof(cufftComplex)*nbin*nsub*ndm));
 
   // Allocate device memory for block sums
-  checkCudaErrors(cudaMalloc((void **) &bs1,sizeof(float)*mblock*mchan));
-  checkCudaErrors(cudaMalloc((void **) &bs2,sizeof(float)*mblock*mchan));
+  checkCudaErrors(cudaMalloc((void **) &bs1, (size_t) sizeof(float)*mblock*mchan));
+  checkCudaErrors(cudaMalloc((void **) &bs2, (size_t) sizeof(float)*mblock*mchan));
 
   // Allocate device memory for channel averages and standard deviations
-  checkCudaErrors(cudaMalloc((void **) &zavg,sizeof(float)*mchan));
-  checkCudaErrors(cudaMalloc((void **) &zstd,sizeof(float)*mchan));
+  checkCudaErrors(cudaMalloc((void **) &zavg, (size_t) sizeof(float)*mchan));
+  checkCudaErrors(cudaMalloc((void **) &zstd, (size_t) sizeof(float)*mchan));
 
   // Allocate memory for redigitized output and header
   header=(char *) malloc(sizeof(char)*HEADERSIZE);
   for (i=0;i<4;i++) {
     h5buf[i]=(char *) malloc(sizeof(char)*nsamp*nsub);
-    checkCudaErrors(cudaMalloc((void **) &dh5buf[i],sizeof(char)*nsamp*nsub));
+    checkCudaErrors(cudaMalloc((void **) &dh5buf[i], (size_t) sizeof(char)*nsamp*nsub));
   }
 
   // Allocate output buffers
   fbuf=(float *) malloc(sizeof(float)*nsamp*nsub);
-  checkCudaErrors(cudaMalloc((void **) &dfbuf,sizeof(float)*nsamp*nsub));
+  checkCudaErrors(cudaMalloc((void **) &dfbuf, (size_t) sizeof(float)*nsamp*nsub));
   cbuf=(unsigned char *) malloc(sizeof(unsigned char)*msamp*mchan/ndec);
-  checkCudaErrors(cudaMalloc((void **) &dcbuf,sizeof(unsigned char)*msamp*mchan/ndec));
+  checkCudaErrors(cudaMalloc((void **) &dcbuf, (size_t) sizeof(unsigned char)*msamp*mchan/ndec));
 
   // Allocate DMs and copy to device
   dm=(float *) malloc(sizeof(float)*ndm);
   for (idm=0;idm<ndm;idm++)
     dm[idm]=dm_start+(float) idm*dm_step;
-  checkCudaErrors(cudaMalloc((void **) &ddm,sizeof(float)*ndm));
+  checkCudaErrors(cudaMalloc((void **) &ddm, (size_t) sizeof(float)*ndm));
   checkCudaErrors(cudaMemcpy(ddm,dm,sizeof(float)*ndm,cudaMemcpyHostToDevice));
 
   // Generate FFT plan (batch in-place forward FFT)

--- a/cdmt.cu
+++ b/cdmt.cu
@@ -239,8 +239,10 @@ int main(int argc,char *argv[])
     startclock=clock();
     for (i=0;i<4;i++)
       nread=fread(h5buf[i],sizeof(char),nsamp*nsub,rawfile[i])/nsub;
-    if (nread==0)
+    if (nread==0) {
+      printf("No data read from last file; assuming EOF, finishng up.\n");
       break;
+    }
     printf("Block: %d: Read %d MB in %.2f s\n",iblock,sizeof(char)*nread*nsub*4/(1<<20),(float) (clock()-startclock)/CLOCKS_PER_SEC);
 
     // Copy buffers to device


### PR DESCRIPTION
Builds upon PR #1 and adds new input flags to allow for 

- Skipping to certain components of raw data files
- Processing a limited amount of time samples

The output header is updated to account for the time skip.

Also adds a timestamp to the current location in the file at the end of dedispersing every block of data.

Goal was to allow for easier analysis of some raw data we had around, where only a small chunk of a long observation was interesting. Tested on my forked version, ported the changes back to your original version so there might be a mis-reference, but it seems to compile fine.

Assumptions:
- Input samples are 1 byte (8-bits) long